### PR TITLE
FTP Test Improvement (95% avg output in watts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "peloton-metrics",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/chart/FtpHistoryChart.svelte
+++ b/src/chart/FtpHistoryChart.svelte
@@ -1,0 +1,80 @@
+<script>
+    import { onMount } from "svelte";
+    import Chart from "chart.js";
+    import Card from "../components/Card.svelte";
+    import * as ChartAnnotation from "chartjs-plugin-annotation";
+    import { ftpAverageOutputs } from "../store/store.js";
+    import moment from "moment";
+
+    const getPlotPoints = (data) => {
+        return data.map((ride) => {
+            // TODO (tmack) find why there are duplicates?
+            console.log(ride);
+            // Functional Threshold Power (FTP) is average output over 1h in 20m tests discount by 5%
+            return {
+                y: Math.floor(ride.average * 0.95),
+                x: moment(ride.createdAt, "YYYY-MM-DD"),
+            };
+        });
+    };
+
+    const getChartData = (data) => {
+        return {
+            datasets: [
+                {
+                    borderColor: "#00cc00",
+                    label: "FTP Tests",
+                    data: getPlotPoints(data),
+                    fill: false,
+                    lineTension: 0,
+                },
+            ],
+        };
+    };
+
+    let ftpHistoryChart;
+
+    let config = {
+        type: "line",
+        plugins: [ChartAnnotation],
+        data: getChartData($ftpAverageOutputs),
+        options: {
+            maintainAspectRatio: false,
+            responsive: true,
+            scales: {
+                xAxes: [
+                    {
+                        type: "time",
+                        distribution: "series",
+                        bounds: "data",
+                        time: {
+                            unit: "day",
+                            tooltipFormat: "MMM DD YYYY",
+                        },
+                    },
+                ],
+            },
+        },
+    };
+
+    onMount(async () => {
+        let ctx = document.getElementById("ftpHistoryChart");
+        ftpHistoryChart = new Chart(ctx, config);
+
+        ftpAverageOutputs.subscribe((value) => {
+            ftpHistoryChart.data = getChartData(value);
+            ftpHistoryChart.update();
+        });
+    });
+</script>
+
+<style>
+    div {
+        min-height: 90vh;
+    }
+</style>
+
+<Card>
+    <h2>Function Threshold Power (FTP) Over Time</h2>
+    <div><canvas id="ftpHistoryChart" /></div>
+</Card>

--- a/src/chart/FtpHistoryChart.svelte
+++ b/src/chart/FtpHistoryChart.svelte
@@ -8,8 +8,6 @@
 
     const getPlotPoints = (data) => {
         return data.map((ride) => {
-            // TODO (tmack) find why there are duplicates?
-            console.log(ride);
             // Functional Threshold Power (FTP) is average output over 1h in 20m tests discount by 5%
             return {
                 y: Math.floor(ride.average * 0.95),

--- a/src/components/MainContent.svelte
+++ b/src/components/MainContent.svelte
@@ -7,7 +7,7 @@
 	import ClassesTakenPerInstructorChart from '../chart/ClassesTakenPerInstructorChart.svelte';
 	import ErrorMessage from '../components/ErrorMessage.svelte';
 	// import PersonalRecords from '../analytics/PersonalRecords.svelte';
-	import {mappedCSVData, classesTakenPerInstructor} from '../store/store.js';
+	import {mappedCSVData, ftpAverageOutputs} from '../store/store.js';
 	import Options from '../options/Options.svelte';
 	import TopFiveSection from '../analytics/TopFiveSection.svelte';
 </script>
@@ -18,7 +18,9 @@
         
         <OutputChart />
 		<AverageOutputChart />
-		<FtpHistoryChart />
+		{#if $ftpAverageOutputs.length > 0}
+			<FtpHistoryChart />
+		{/if}
         <!-- <PersonalRecords /> // May use this again but needs styling-->
 		<ClassesTakenPerInstructorChart />
 		<AverageCadenceResistanceChart />

--- a/src/components/MainContent.svelte
+++ b/src/components/MainContent.svelte
@@ -1,6 +1,7 @@
 <script>
     import CSVUpload from '../data/CSVUpload.svelte';
 	import OutputChart from '../chart/OutputChart.svelte';
+	import FtpHistoryChart from '../chart/FtpHistoryChart.svelte';
 	import AverageOutputChart from '../chart/AverageOutputChart.svelte';
 	import AverageCadenceResistanceChart from '../chart/AverageCadenceResistanceChart.svelte';
 	import ClassesTakenPerInstructorChart from '../chart/ClassesTakenPerInstructorChart.svelte';
@@ -16,7 +17,8 @@
 		<Options />
         
         <OutputChart />
-        <AverageOutputChart />
+		<AverageOutputChart />
+		<FtpHistoryChart />
         <!-- <PersonalRecords /> // May use this again but needs styling-->
 		<ClassesTakenPerInstructorChart />
 		<AverageCadenceResistanceChart />

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -2,6 +2,7 @@ import { writable, readable, derived } from 'svelte/store';
 import {
     filterRidesByTitle, 
     organizeRidesByLength, 
+    energy,
     getAverageOutputs, 
     getBestRidesByLength, 
     getUniqueRideTypes, 
@@ -58,6 +59,9 @@ export const ftpTestRides  = derived([mappedCSVData, ftpTestFilter],
 
 // Get average outputs
 export const averageOutputs = derived(filteredData, $filteredData => getAverageOutputs($filteredData));
+
+// need to store ftpRides somewhere
+export const ftpAverageOutputs = derived(ftpTestRides, $ftpTestRides => getAverageOutputs($ftpTestRides, energy.WATTS));
 
 export const averageCadence = derived(filteredData, $filteredData => getAverageCadence($filteredData));
 

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -28,6 +28,8 @@ export const showAverages = writable(true);
 // Initialize filters
 export const rideTitleFilters = writable(["Intervals & Arms", "Cool Down", "Warm Up", "Recovery"]);
 
+export const ftpTestFilter = writable(["FTP Test Ride"]);
+
 export const showSameDayRides = writable(false);
 
 export const mappedCSVData = derived([csvData, selectedFitnessDiscipline, showSameDayRides, ridesToShow],
@@ -49,6 +51,10 @@ export const rideTypes = derived(mappedCSVData, $mappedCSVData => getUniqueRideT
 
 export const filteredData = derived([mappedCSVData, rideTitleFilters], 
     ([$mappedCSVData, $rideTitleFilters]) => filterRidesByTitle($mappedCSVData, $rideTitleFilters));
+
+// get FTP Test Rides
+export const ftpTestRides  = derived([mappedCSVData, ftpTestFilter],
+    ([$mappedCSVData, $ftpTestFilter]) => filterRidesByTitle($mappedCSVData, $ftpTestFilter, true));
 
 // Get average outputs
 export const averageOutputs = derived(filteredData, $filteredData => getAverageOutputs($filteredData));

--- a/src/store/storeUtils.js
+++ b/src/store/storeUtils.js
@@ -1,12 +1,15 @@
 import {getAverageEffort, getColor} from '../chart/chartUtils.js';
 
-export const filterRidesByTitle = (data, filters) => {
+export const filterRidesByTitle = (data, filters, matching = false) => {
     let filteredData = data.filter(ride => {
         let isFiltered = false;
         if (ride.title){
             filters.forEach(filter => {
                 if (ride.title.includes(filter)){
-                    isFiltered = true;
+                    // default is to filter out matching
+                    isFiltered = !matching;
+                } else {
+                    isFiltered = matching;
                 }
             });
         }
@@ -72,12 +75,18 @@ export const getBestRidesByLength = (data) => {
     return bestRides;
 }
 
-export const getAverageOutputs = (data) => {
+export const energy = {
+    WATTS: 'watts',
+    KILOJOULES: 'kj'
+}
+
+export const getAverageOutputs = (data, units = energy.KILOJOULES ) => {
     let outputs = [];
     data.forEach(ride => {
         let averageOutputPerMinute = ride.output/ride.duration;
         let output = {};
-        output["average"] = averageOutputPerMinute;
+        output["average"] = units == energy.KILOJOULES ? averageOutputPerMinute : ride.averageOutput;
+        output['title'] = ride.title;
         output["createdAt"] = ride.date;
         outputs.push(output);
     })
@@ -94,6 +103,7 @@ export const mapCSVData = (data, discipline = "Cycling", ridesToShow) => {
             let timestamp = effort["Workout Timestamp"];
             ride.date = timestamp.substr(0, timestamp.indexOf(' '));
             ride.output = parseInt(effort["Total Output"]);
+            ride.averageOutput = parseInt(effort["Avg. Watts"]);
             ride.title = effort["Title"];
             ride.duration = parseInt(effort["Length (minutes)"]);
             ride.instructor = effort["Instructor Name"];


### PR DESCRIPTION
FTP is typically measure in average output in watts from 1hr of cycling. Instead of a 60m test ride Peloton and pro cyclists have been using a 20m test ride to use as a baseline number. The calculation of the normal FTP metric for average output then is discounted 5% based on only going for 20m vs the normal of 60m to get to your average output over 60m.

Lots to read from Matt Wilpers if interested, http://blog.mattwilpers.com/ftp-testing/

Here is my FTP improvement graph using this code.

![image](https://user-images.githubusercontent.com/2158627/96598106-8a65a180-12bc-11eb-9fa2-939570cfa754.png)

I want to improve this by also calculating "% change" between each data point in my case that would be +17.51%, but still need to learn how to setup dual axis measurements to properly display this information.