### PR TITLE
Fix Color Selector on Large Data Sets (data.length > colors.length)

### DIFF
--- a/src/chart/chartUtils.js
+++ b/src/chart/chartUtils.js
@@ -2,7 +2,7 @@ export const getColor = (lengthOfArray, index) => {
 	// Vaguely the colors of the rainbow. Idea is to gradually move up to red for the hardest rides.
 	const colorPalette = ["#e60000", "#ff4d88", "#e65c00", "#ffcc00", "#00cc00","#00cccc", "#008ae6", "#6666ff", "#7300e6"].reverse();
 	// Most people only do a few different distances, don't want it to always be the first three colors of the rainbow. This allows spreading through evenly depending on how many different lengths of ride the user has done.
-	let skip = Math.floor(colorPalette.length/lengthOfArray);  
+	let skip = Math.max(1, Math.floor(colorPalette.length/lengthOfArray));  
 	let arrayValue = index*skip;
 	let color = colorPalette[arrayValue];
 


### PR DESCRIPTION
**Existing Behavior**
When a user has rides with more than 9 instructors every instructor 1-9 will appear with the first color in the colors array.
`Math.floor(9/10) == 0`

![image](https://user-images.githubusercontent.com/2158627/96630743-74b7a280-12e3-11eb-871a-b9d9ecbacad9.png)


**Proposed Solution**
`max(1, floor(9/10)) == 1`

![image](https://user-images.githubusercontent.com/2158627/96630908-a892c800-12e3-11eb-8ee8-50724b222f4a.png)
